### PR TITLE
Adding OpenFin typings file as a dev dependency

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -6,6 +6,7 @@
         "test": "grunt test"
     },
     "devDependencies": {
+        "@types/openfin": "^16.0.1",
         "grunt-contrib-watch": "^0.6.1",
         "grunt-jsbeautifier": "^0.2.7",
         "grunt": "^0.4.5",


### PR DESCRIPTION
This simply adds the OpenFin typings file as a dev dependency, which enables auto-completion out-of-the-box for the `fin.*` namespace, when authoring in an IDE/editor that supports it (e.g. Visual Studio Code).

![image](https://cloud.githubusercontent.com/assets/116461/23836712/d02a5a68-0739-11e7-8d7d-0d411c350a4a.png)
