### PR TITLE
Adding JSON schema support for app.json

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -73,6 +73,10 @@ var OpenfinGeneratorGenerator = yeoman.generators.Base.extend({
         projectfiles: function() {
             this.src.copy('editorconfig', '.editorconfig');
             this.src.copy('jshintrc', '.jshintrc');
+
+            // VSCode editor settings
+            this.dest.mkdir('.vscode');
+            this.src.copy('.vscode/settings.json', '.vscode/settings.json');
         }
     },
 

--- a/app/templates/.vscode/settings.json
+++ b/app/templates/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "json.schemas": [
+        {
+            "fileMatch": ["app.json"],
+            "url": "http://json.schemastore.org/openfin"
+        }
+    ]
+}


### PR DESCRIPTION
This adds a VS Code workspace setting file to the generated app, which enables auto-completion for the `app.json` file out-of-the-box. This makes it a lot simpler to author this file and explore the available options *(see image below)*.

Let me know if you're cool with adding VS Code-specific assets by default, or if we should prompt the user whether they'd like them or not. I'd like to also contribute some basic debugging support for OpenFin/VS Code, and I'll add that however we decide for this PR.

> This makes use of the OpenFin JSON schema that I created and [submitted to the SchemaStore repo](https://github.com/SchemaStore/schemastore/pull/280). As the config schema changes with new OpenFin versions, we can simply update the schema on SchemaStore, and this generator/apps will automatically pick it up.

![image](https://cloud.githubusercontent.com/assets/116461/23877153/52f6791c-0817-11e7-9cb8-1991789f41f0.png)
